### PR TITLE
Patient View Finished Requests Page

### DIFF
--- a/mister-ed/db.json
+++ b/mister-ed/db.json
@@ -436,6 +436,7 @@
   "triage_records": [
     {
       "id": "23",
+      "lastModified": "2024-11-14T15:44:25.582Z",
       "patientID": "1",
       "nurseID": "",
       "description": "My arm hurts!",

--- a/mister-ed/src/pages/homepage/triage/RequestTriage.js
+++ b/mister-ed/src/pages/homepage/triage/RequestTriage.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Button, FormControl, InputLabel, Select, MenuItem, Box } from '@mui/material';
+import { Button, FormControl, InputLabel, Select, MenuItem, Box, TextField, Grid } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import DatabaseClient from '../../../clients/DatabaseClient';
 
@@ -9,6 +9,7 @@ function RequestTriage() {
 	const [error, setError] = useState('');
   const navigate = useNavigate();
   const [queuePosition, setQueuePosition] = useState(null);
+  const [triageRequestDescription, setTriageRequestDescription] = useState();
 
   useEffect(() => {
     const fetchHospitals = async () => {
@@ -30,6 +31,10 @@ function RequestTriage() {
       setError('Please select a hospital.');
       return;
     }
+    if (!triageRequestDescription) {
+      setError('Please provide a reason.');
+      return;
+    }
     
     try {
 			// Fetch hospital data to get queue count
@@ -48,59 +53,87 @@ function RequestTriage() {
   
   const selectedHospitalDetails = hospitals.find(hospital => hospital.id === selectedHospital);
 
-  const handleLogout = () => {
-    navigate('/login');
-  };
-
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: '50px' }}>
-      <h1>Request Triage</h1>
-      {queuePosition ? (
-				<p>
-					You are in the queue for <strong>{selectedHospitalDetails?.name}</strong>.
-					Your position in the queue: {queuePosition}
-				</p>
-      ) : (
-				<form onSubmit={handleSubmit} style={{ maxWidth: '400px', margin: '0 auto' }}>
-					<FormControl fullWidth margin='normal' variant='outlined'>
-						<InputLabel id='hospital-select-label' shrink>
-							Hospital
-						</InputLabel>
-						<Select
-							labelId='hospital-select-label'
-							value={selectedHospital}
-							onChange={(e) => setSelectedHospital(e.target.value)}
-							fullWidth
-						>
-							{hospitals.map((hospital) => (
-								<MenuItem key={hospital.id} value={hospital.id}>
-									{hospital.name}
-								</MenuItem>
-							))}
-						</Select>
-					</FormControl>
-					{error && <p style={{ color: 'red' }}>{error}</p>}{' '}
-					<Button
-						type="submit"
-						variant="contained"
-						color="error"
-						style={{ marginTop: '20px', width: '100%' }}
-					>
-						Submit
-					</Button>
-				</form>
-			)}
-      {/* Logout Button */}
-      <Box mt={4}>
-        <Button 
-          variant="contained" 
-          color="secondary" 
-          onClick={handleLogout} 
-          style={{ padding: '10px 40px' }}
-        >
-          Logout
-        </Button>
-      </Box>
+    <div>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: '50px' }}>
+        <h1>Request Triage</h1>
+        {/* Grid of buttons */}
+        <Grid container spacing={2} justifyContent="center" style={{ maxWidth: '600px' }}>
+          <Grid item xs={6}>
+            <Button
+              variant="contained"
+              color="error"
+              fullWidth
+              style={{ padding: '20px' }}
+              onClick={() => navigate('/home')}
+            >
+              Home Page
+            </Button>
+          </Grid>
+          <Grid item xs={6}>
+            <Button
+              variant="contained"
+              color="error"
+              fullWidth
+              style={{ padding: '20px' }}
+              onClick={() => navigate('/triage')}
+            >
+              Triage
+            </Button>
+          </Grid>
+        </Grid>
+      </div>
+      {/* Main content */}
+      <div style={{ maxWidth: '400px', margin: '0 auto', textAlign: 'center', marginTop: '50px' }}>
+        {queuePosition ? (
+          <p>
+            You are in the queue for <strong>{selectedHospitalDetails?.name}</strong>.
+            Your position in the queue: {queuePosition}
+          </p>
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <FormControl fullWidth margin='normal'>
+              {/* Hospital select dropdown */}
+              <InputLabel id='hospital-select-label'>
+                Hospital
+              </InputLabel>
+              <Select
+                labelId='hospital-select-label'
+                value={selectedHospital}
+                onChange={(e) => setSelectedHospital(e.target.value)}
+                fullWidth
+              >
+                {hospitals.map((hospital) => (
+                  <MenuItem key={hospital.id} value={hospital.id}>
+                    {hospital.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            {/* Reason text box */}
+            <TextField
+              label="Reason"
+              fullWidth
+              multiline
+              rows={4}
+              margin='normal'
+              value={triageRequestDescription}
+              onChange={(e) => setTriageRequestDescription(e.target.value)}
+            />
+            {/* Submit button */}
+            <Button
+              type="submit"
+              variant="contained"
+              color="error"
+              style={{ marginTop: '20px', width: '100%' }}
+              fullWidth
+            >
+              Submit Request
+            </Button>
+            {error && <p style={{ color: 'red' }}>{error}</p>}{' '}
+          </form>
+        )}
+      </div>
     </div>
   );
 }

--- a/mister-ed/src/pages/homepage/triage/Triage.js
+++ b/mister-ed/src/pages/homepage/triage/Triage.js
@@ -1,44 +1,169 @@
-import React from 'react';
-import { Button, Grid, Box } from '@mui/material';
+import React, {useEffect, useState } from 'react';
+import { Button, Grid, Box, FormControl, InputLabel, Select, MenuItem } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
+import Logger from '../../../logging/Logger';
+import DatabaseClient from '../../../clients/DatabaseClient'
+
+const logger = new Logger();
 
 function Triage() {
+  const [user, setUser] = useState(null);
+  const [triageRecords, setTriageRecords] = useState([]);
+  const [selectedRecord, setSelectedRecord] = useState(null);
+  const [nurseName, setNurseName] = useState(null);
   const navigate = useNavigate();
+  const [showInitialMessage, setShowInitialMessage] = useState(true);
 
+  useEffect(() => {
+    // Load user data from localStorage
+    const userData = localStorage.getItem('user');
+    if (userData) {
+      try {
+        const parsedUser = JSON.parse(userData);
+        setUser(parsedUser);
+        fetchTriageRecords(parsedUser.id); // Use parsedUser.id directly to avoid relying on delayed state update and prevent race condition
+      } catch (error) {
+        logger.error(`Error parsing user data in Triage Page`, error);
+      }
+    }
+  }, []);
+  
+  const fetchTriageRecords = async (patientID) => {
+    try {
+      const data = await DatabaseClient.fetch('triage_records');
+      // Filter records for those that match the patient's ID and contain results (i.e., outcome is not empty)
+      const patientRecords = data
+        .filter(record => record.patientID === patientID && record.outcome) /* Remove "&& record.outcome" to get all records */
+        .sort((a, b) => new Date(b.lastModified) - new Date(a.lastModified)); /* Order the records with the most recent date first */
+      setTriageRecords(patientRecords);
+      if (patientRecords.length > 0) setSelectedRecord(patientRecords[0]); // Set the latest record as the initially selected record
+    } catch (error) {
+      logger.info('No matching triage records found');
+    }
+  };
+  
+  const getNurseName = async (nurseID) => {
+    if (!nurseID) {
+      setNurseName("Unknown");
+      return;
+    }
+    try {
+      const data = await DatabaseClient.fetch('nurses');
+      const foundNurse = data?.find((nurse) => nurse.id === nurseID);
+      setNurseName(foundNurse ? foundNurse.name : "Unknown");
+    } catch (error) {
+      logger.info('Failure fetching data');
+      console.error('Error fetching data:', error);
+      setNurseName("Unknown");
+    }
+  };
+  
+  useEffect(() => {
+    if (selectedRecord) {
+      getNurseName(selectedRecord.nurseID);
+    }
+  }, [selectedRecord]); // Trigger when selectedRecord changes
+  
+  const formatDate = (isoString) => {
+    const date = new Date(isoString);
+    return new Intl.DateTimeFormat('en-US', {
+      weekday: 'long',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric'
+    }).format(date);
+  };
+  
   const handleLogout = () => {
     navigate('/login');
   };
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: '50px' }}>
-      <h1>Triage</h1>
-
-      {/* Grid of buttons */}
-      <Grid container spacing={2} justifyContent="center" style={{ maxWidth: '600px' }}>
-        <Grid item xs={6}>
-          <Button
-            variant="contained"
-            color="error"
-            fullWidth
-            style={{ padding: '20px' }}
-            onClick={() => navigate('/home')}
-          >
-            Home Page
-          </Button>
+    <div>
+      <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', paddingTop: '50px' }}>
+        <h1>Triage</h1>
+        
+        {/* Grid of buttons */}
+        <Grid container spacing={2} justifyContent="center" style={{ maxWidth: '600px' }}>
+          <Grid item xs={6}>
+            <Button
+              variant="contained"
+              color="error"
+              fullWidth
+              style={{ padding: '20px' }}
+              onClick={() => navigate('/home')}
+            >
+              Home Page
+            </Button>
+          </Grid>
+          <Grid item xs={6}>
+            <Button
+              variant="contained"
+              color="error"
+              fullWidth
+              style={{ padding: '20px' }}
+              onClick={() => navigate('/request-triage')}
+            >
+              Request Triage
+            </Button>
+          </Grid>
         </Grid>
-        <Grid item xs={6}>
-          <Button 
-            variant="contained" 
-            color="error" 
-            fullWidth 
-            style={{ padding: '20px' }} 
-            onClick={() => navigate('/request-triage')}
-          >
-			Request Triage
-          </Button>
-        </Grid>
-      </Grid>
-
+      </div>
+        
+      {/* Message */}
+      {triageRecords.length > 0 ? (
+        showInitialMessage && (
+          <div style={{ textAlign: 'center', margin: '0 auto', marginTop: '50px'}}>
+            Below are the results from your last triage. Alternatively, you may view results from any of your past triages.
+          </div>
+        )
+      ) : (
+        <div style={{ textAlign: 'center', margin: '0 auto', marginTop: '50px'}}>
+          You have no triage results to display. Your results from all future triages will be available here.
+        </div>
+      )}
+        
+      <div style={{ maxWidth: '400px', margin: '0 auto', textAlign: 'center', marginTop: '50px' }}>
+        
+        {/* Dropdown to select record */}
+        {triageRecords.length > 0 && (
+          <FormControl fullWidth margin='normal'>
+            <InputLabel id='record-select-label'>
+              Triage Record
+            </InputLabel>
+            <Select
+              labelId='record-select-label'
+              value={selectedRecord?.id || ""}
+              onChange={(e) => {
+                const selectedId = e.target.value;
+                const record = triageRecords.find((rec) => rec.id === selectedId);
+                setSelectedRecord(record);
+                getNurseName(record.nurseID);
+                // Hide the initial message once the selected record is different from the initially selected record (i.e., the latest)
+                if (record.id != triageRecords[0].id) setShowInitialMessage(false);
+              }}
+              fullWidth
+            >
+              {triageRecords.map((record) => (
+                <MenuItem key={record.id} value={record.id}>
+                  {formatDate(record.lastModified)} - {record.description}
+                </MenuItem>
+              ))}
+            </Select>
+            
+            {/* Display details for selected record */}
+            {selectedRecord && (
+              <div style={{ marginTop: '50px', textAlign: 'left' }}>
+                <div><strong>Date:</strong> {formatDate(selectedRecord.lastModified)}</div>
+                <div><strong>Description:</strong> {selectedRecord.description}</div>
+                <div><strong>Outcome:</strong> {selectedRecord.outcome}</div>
+                <div><strong>Nurse:</strong> {nurseName}</div>
+              </div>
+            )}
+            
+          </FormControl>
+        )}
+      </div>
     </div>
   );
 }

--- a/mister-ed/src/pages/homepage/triage/Triage.js
+++ b/mister-ed/src/pages/homepage/triage/Triage.js
@@ -16,6 +16,17 @@ function Triage() {
       {/* Grid of buttons */}
       <Grid container spacing={2} justifyContent="center" style={{ maxWidth: '600px' }}>
         <Grid item xs={6}>
+          <Button
+            variant="contained"
+            color="error"
+            fullWidth
+            style={{ padding: '20px' }}
+            onClick={() => navigate('/home')}
+          >
+            Home Page
+          </Button>
+        </Grid>
+        <Grid item xs={6}>
           <Button 
             variant="contained" 
             color="error" 
@@ -28,17 +39,6 @@ function Triage() {
         </Grid>
       </Grid>
 
-      {/* Logout Button */}
-      <Box mt={4}>
-        <Button 
-          variant="contained" 
-          color="secondary" 
-          onClick={handleLogout} 
-          style={{ padding: '10px 40px' }}
-        >
-          Logout
-        </Button>
-      </Box>
     </div>
   );
 }


### PR DESCRIPTION
This completes #19.

# Here is a summary of what I did:

## Feature
### Change
- Added an input field to the triage request form<br>


### Rationale

I noticed that the existing sample triage record in [db.json](https://github.com/SENG-350-2024-fall/Team-8/blob/19-patient-view-finished-requests-page/mister-ed/db.json) included a `description` field, but there was currently no way of obtaining this information in the first place.
## Style
### Change
- Adjusted layout of triage pages
  - Moved/added navigation buttons along the top to match the homepage layout
  - Styled triage request form to match the support ticket form


### Rationale

I wanted to make the triage pages more consistent with the rest of the app and incorporate some of the good designs from other pages.
## Feature
### Change
- Implemented the creation of a triage record in the mock database upon triage request


### Rationale

The content from the triage request form was not being stored anywhere.
## Chore
### Change
- Added a date field to the existing sample triage record in [db.json](https://github.com/SENG-350-2024-fall/Team-8/blob/19-patient-view-finished-requests-page/mister-ed/db.json)


### Rationale

Since a timestamp is stored alongside the triage record, I had to update the existing sample triage record with that new piece of information.
## Feature
### Change
- Implemented the display of triage records on the main triage page


### Rationale

As per #19.