### PR TITLE
Triage Queue Hospital Specificity

### DIFF
--- a/mister-ed/db.json
+++ b/mister-ed/db.json
@@ -103,70 +103,70 @@
       "email": "nurse.alex@example.com",
       "password": "nurseAlex123",
       "name": "Alex Thompson",
-      "hospital": "Victoria General"
+      "hospitalID": "2"
     },
     {
       "id": "2",
       "email": "nurse.lucy@example.com",
       "password": "nurseLucy456",
       "name": "Lucy Evans",
-      "hospital": "Royal Jubilee"
+      "hospitalID": "3"
     },
     {
       "id": "3",
       "email": "nurse.james@example.com",
       "password": "nurseJames789",
       "name": "James White",
-      "hospital": "Victoria General"
+      "hospitalID": "2"
     },
     {
       "id": "4",
       "email": "nurse.olivia@example.com",
       "password": "nurseOlivia123",
       "name": "Olivia Harris",
-      "hospital": "Royal Jubilee"
+      "hospitalID": "3"
     },
     {
       "id": "5",
       "email": "nurse.michael@example.com",
       "password": "nurseMichael456",
       "name": "Michael Clark",
-      "hospital": "Victoria General"
+      "hospitalID": "2"
     },
     {
       "id": "6",
       "email": "nurse.chloe@example.com",
       "password": "nurseChloe789",
       "name": "Chloe Lewis",
-      "hospital": "Royal Jubilee"
+      "hospitalID": "3"
     },
     {
       "id": "7",
       "email": "nurse.david@example.com",
       "password": "nurseDavid123",
       "name": "David Robinson",
-      "hospital": "Victoria General"
+      "hospitalID": "2"
     },
     {
       "id": "8",
       "email": "nurse.sarah@example.com",
       "password": "nurseSarah456",
       "name": "Sarah Walker",
-      "hospital": "Royal Jubilee"
+      "hospitalID": "1"
     },
     {
       "id": "9",
       "email": "nurse.daniel@example.com",
       "password": "nurseDaniel789",
       "name": "Daniel King",
-      "hospital": "Victoria General"
+      "hospitalID": "1"
     },
     {
       "id": "10",
       "email": "nurse.julia@example.com",
       "password": "nurseJulia123",
       "name": "Julia Scott",
-      "hospital": "Royal Jubilee"
+      "hospitalID": "1"
     }
   ],
   "emts": [
@@ -247,70 +247,70 @@
       "email": "doctor.john@example.com",
       "password": "doctorJohn123",
       "name": "John Carter",
-      "hospital": "Victoria General"
+      "hospitalID": "2"
     },
     {
       "id": "2",
       "email": "doctor.emma@example.com",
       "password": "doctorEmma456",
       "name": "Emma Clark",
-      "hospital": "Royal Jubilee"
+      "hospitalID": "3"
     },
     {
       "id": "3",
       "email": "doctor.william@example.com",
       "password": "doctorWilliam789",
       "name": "William Foster",
-      "hospital": "Victoria General"
+      "hospitalID": "2"
     },
     {
       "id": "4",
       "email": "doctor.sophia@example.com",
       "password": "doctorSophia123",
       "name": "Sophia Bell",
-      "hospital": "Royal Jubilee"
+      "hospitalID": "3"
     },
     {
       "id": "5",
       "email": "doctor.jacob@example.com",
       "password": "doctorJacob456",
       "name": "Jacob Price",
-      "hospital": "Victoria General"
+      "hospitalID": "2"
     },
     {
       "id": "6",
       "email": "doctor.ava@example.com",
       "password": "doctorAva789",
       "name": "Ava Perry",
-      "hospital": "Royal Jubilee"
+      "hospitalID": "3"
     },
     {
       "id": "7",
       "email": "doctor.mason@example.com",
       "password": "doctorMason123",
       "name": "Mason Green",
-      "hospital": "Victoria General"
+      "hospitalID": "2"
     },
     {
       "id": "8",
       "email": "doctor.isabella@example.com",
       "password": "doctorIsabella456",
       "name": "Isabella Young",
-      "hospital": "Royal Jubilee"
+      "hospitalID": "1"
     },
     {
       "id": "9",
       "email": "doctor.elijah@example.com",
       "password": "doctorElijah789",
       "name": "Elijah Turner",
-      "hospital": "Victoria General"
+      "hospitalID": "1"
     },
     {
       "id": "10",
       "email": "doctor.mia@example.com",
       "password": "doctorMia123",
       "name": "Mia Sanders",
-      "hospital": "Royal Jubilee"
+      "hospitalID": "1"
     }
   ],
   "admins": [

--- a/mister-ed/db.json
+++ b/mister-ed/db.json
@@ -440,7 +440,8 @@
       "patientID": "1",
       "nurseID": "",
       "description": "My arm hurts!",
-      "outcome": ""
+      "outcome": "",
+      "hospitalID": "1"
     }
   ]
 }

--- a/mister-ed/src/App.js
+++ b/mister-ed/src/App.js
@@ -17,6 +17,7 @@ import Triage from './pages/homepage/triage/Triage';
 import RequestTriage from './pages/homepage/triage/RequestTriage';
 import Profile from './pages/homepage/profile/Profile';
 import HomeEMT from './pages/homepage/HomeEMT';
+import { QueueProvider } from './context/QueueContext';
 import './App.css';
 
 function App() {
@@ -33,7 +34,7 @@ function App() {
           <Route path="/ticket-details/:id" element={<TicketDetailPage />} />
 		      <Route path="/triage" element={<Triage />} />
 		      <Route path="/request-triage" element={<RequestTriage />} />
-          <Route path='/perform-triage' element={<PerformTriage />} />
+          <Route path='/perform-triage' element={<QueueProvider><PerformTriage /></QueueProvider>} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/homeEMT" element={<HomeEMT />} />
           <Route path="/" element={<Navigate to="/landing" />} />

--- a/mister-ed/src/clients/TriageQueueClient.js
+++ b/mister-ed/src/clients/TriageQueueClient.js
@@ -1,35 +1,27 @@
 class TriageQueueClient {
-    static #instance = null; // Use a protected static instance
-    static #port = null; // Use a protected static port property
+    #port = null;
+    #hospitalID = null;
 
-    constructor(port) {
-        if (TriageQueueClient.#instance) {
-            throw new Error(
-                `${new.target.name} is a singleton class. Use ${
-                    new.target.name
-                }.getInstance() to access the instance.`
-            );
+    constructor(hospitalID, port = 3003) {
+        if (!hospitalID) {
+            throw new Error('Hospital ID is required to create a TriageQueueClient instance.');
         }
-
-        if (port !== undefined) {
-            TriageQueueClient.#port = port; // Set the port in the static property
-        }
+        this.#hospitalID = hospitalID;
+        this.#port = port;
     }
 
-    static getInstance(port) {
-        if (!this.#instance) {
-            this.#instance = new this(port); // Calls the constructor of the subclass with the port
-        }
-        return this.#instance;
+    get hospitalID() {
+        return this.#hospitalID;
     }
 
     get port() {
-        return TriageQueueClient.#port; // Access the static protected port property
+        return this.#port;
     }
 
     // POST request
     async push(item) {
-        const response = await fetch(`http://localhost:${this.port}/queue`, {
+        if (!this.#hospitalID) throw new Error('Hospital ID is not set.');
+        const response = await fetch(`http://localhost:${this.#port}/queue/${this.#hospitalID}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ item }),
@@ -45,7 +37,8 @@ class TriageQueueClient {
 
     // DELETE request
     async pop() {
-        const response = await fetch(`http://localhost:${this.port}/queue`, {
+        if (!this.#hospitalID) throw new Error('Hospital ID is not set');
+        const response = await fetch(`http://localhost:${this.#port}/queue/${this.#hospitalID}`, {
             method: 'DELETE',
         });
 
@@ -59,4 +52,4 @@ class TriageQueueClient {
     }
 }
 
-export default TriageQueueClient.getInstance(3003);
+export default TriageQueueClient;

--- a/mister-ed/src/context/QueueContext.js
+++ b/mister-ed/src/context/QueueContext.js
@@ -1,0 +1,46 @@
+import React, { useState, useEffect, createContext, useContext, useMemo } from 'react';
+import TriageQueueClient from '../clients/TriageQueueClient';
+import Logger from '../logging/Logger';
+
+const logger = new Logger();
+const QueueContext = createContext(); // Create a context
+
+export const QueueProvider = ({ children }) => {
+
+  const [queueClient, setQueueClient] = useState(null);
+  const [isReady, setIsReady] = useState(false); // Track initialization readiness
+  
+  useEffect(() => {
+    // Load nurse's user data from localStorage
+    const userData = localStorage.getItem('user');
+    if (userData) {
+      try {
+        const parsedUser = JSON.parse(userData);
+        // Create a queue client for the nurse's hospital
+        const initializedClient = new TriageQueueClient(parsedUser.hospitalID);
+        setQueueClient(initializedClient);
+        // Delay readiness until queue client is properly initialized
+        if (initializedClient) {
+          setIsReady(true);
+        }
+      } catch (error) {
+        logger.error(`Error parsing user data for the triage queue`, error);
+        throw error;
+      }
+    }
+  }, []);
+  
+  // Return updated context values
+  const contextValue = { queueClient, isReady };
+  return <QueueContext.Provider value={contextValue}>{children}</QueueContext.Provider>;
+  
+};
+
+// Create a custom hook for accessing the context
+export const useQueue = () => {
+  const context = useContext(QueueContext);
+  if (!context) {
+    throw new Error('Queue client is not ready. Ensure you are accessing it after initialization.');
+  }
+  return context;
+};

--- a/mister-ed/src/hooks/useNextPatient.js
+++ b/mister-ed/src/hooks/useNextPatient.js
@@ -1,0 +1,30 @@
+import { useQueue } from '../context/QueueContext';
+import Logger from '../logging/Logger';
+
+const logger = new Logger();
+
+const useNextPatient = () => {
+
+  const { queueClient, isReady } = useQueue(); // Access both queueClient and readiness state
+  
+  const getNextPatient = async () => {
+    if (!isReady || !queueClient) {
+      console.error('Cannot fetch the next patient: Queue client is not initialized.');
+      throw new Error('Queue client is not initialized.');
+    }
+    try {
+      // Pop and return the next triage record ID
+      const patientRecord = await queueClient.pop();
+      return patientRecord;
+    } catch (error) {
+      logger.error('Error fetching the next triage record from the queue', error);
+      console.error('Failed to get next patient:', error);
+      throw error;
+    }
+  };
+  
+  return { getNextPatient, isReady, queueClient };
+  
+};
+
+export default useNextPatient;

--- a/mister-ed/src/pages/Login.js
+++ b/mister-ed/src/pages/Login.js
@@ -49,6 +49,10 @@ function Login() {
                 // Only reason UserFactory is called instead of just using UserData is so that we also have user permissions
                 // which are only set using UserFactory.
                 const user = UserFactory.createUser(accountType,foundUser.name, foundUser.email, foundUser.password, foundUser.age, foundUser.postal);
+                
+                // Add hospitalID only for nurses and doctors
+                const hospitalID = (accountType === 'Nurse' || accountType === 'Doctor') ? foundUser.hospitalID : undefined;
+                
                 const userData = {
                     id: foundUser.id,
                     name: user.name,
@@ -57,7 +61,8 @@ function Login() {
                     age: user.age,
                     postal: user.postal,
                     permissions: user.permissions,
-                    role: accountType
+                    role: accountType,
+                    ...(hospitalID && { hospitalID }) // Add hospitalID only if it's defined
                   };
 
             // Store the user object in localStorage

--- a/mister-ed/src/pages/homepage/profile/Profile.js
+++ b/mister-ed/src/pages/homepage/profile/Profile.js
@@ -2,24 +2,36 @@ import React, { useEffect, useState } from 'react';
 import { Button, Grid, Box } from '@mui/material'; // Import Button, Grid, and Box from MUI
 import { useNavigate } from 'react-router-dom'; // Import useNavigate
 import Logger from '../../../logging/Logger';
+import DatabaseClient from '../../../clients/DatabaseClient'
 
 const LOG = new Logger();
 
 function Profile() {
   const [user, setUser] = useState(null);
+  const [hospitalName, setHospitalName] = useState(null);
   const navigate = useNavigate(); // Initialize useNavigate hook
 
   useEffect(() => {
     const userData = localStorage.getItem('user');
     if (userData) {
       try {
-        setUser(JSON.parse(userData));
-        console.log(JSON.parse(userData));
+        const parsedUser = JSON.parse(userData);
+        setUser(parsedUser);
+        console.log(parsedUser);
+        if (parsedUser.hospitalID) fetchHospitalName(parsedUser.hospitalID);
       } catch (error) { 
         LOG.error(`Error parsing user data in Profile Page`, error);
       }
     }
   }, []);
+
+  const fetchHospitalName = async (hospitalID) => {
+    const hospitals = await DatabaseClient.fetch('hospitals');
+    const foundHospital = hospitals?.find(
+      (hospital) => String(hospital.id) === String(hospitalID)
+    );
+    if (foundHospital) setHospitalName(foundHospital.name);
+  };
 
   // Function to handle going back
   const handleGoBack = () => {
@@ -42,6 +54,9 @@ function Profile() {
           <p><strong>Age:</strong> {user.age}</p>
           <p><strong>Postal Code:</strong> {user.postal}</p>
           <p><strong>Role:</strong> {user.role}</p>
+          {hospitalName && (
+            <p><strong>Hospital:</strong> {hospitalName}</p>
+          )}
         </div>
       ) : (
         <p>Loading user information...</p>

--- a/mister-ed/src/pages/homepage/triage/PerformTriage.js
+++ b/mister-ed/src/pages/homepage/triage/PerformTriage.js
@@ -26,8 +26,6 @@ function PerformTriage() {
         try {
             let recordID;
 
-            TriageQueueClient.push(23); //remove this once the queue is implemented in the patient side.
-
             try {
                 recordID = await TriageQueueClient.pop();
             } catch (err) {

--- a/mister-ed/src/pages/homepage/triage/RequestTriage.js
+++ b/mister-ed/src/pages/homepage/triage/RequestTriage.js
@@ -73,6 +73,7 @@ function RequestTriage() {
         nurseID: '', // Initially empty
         description: triageRequestDescription,
         outcome: '', // Initially empty
+        hospitalID: selectedHospital,
       };
       
       const response = await DatabaseClient.post('triage_records', recordData);

--- a/mister-ed/src/pages/homepage/triage/RequestTriage.js
+++ b/mister-ed/src/pages/homepage/triage/RequestTriage.js
@@ -3,6 +3,7 @@ import { Button, FormControl, InputLabel, Select, MenuItem, Box, TextField, Grid
 import { useNavigate } from 'react-router-dom';
 import DatabaseClient from '../../../clients/DatabaseClient';
 import Logger from '../../../logging/Logger';
+import TriageQueueClient from '../../../clients/TriageQueueClient';
 
 const logger = new Logger();
 
@@ -78,6 +79,8 @@ function RequestTriage() {
       
       const response = await DatabaseClient.post('triage_records', recordData);
       if (response.ok) {
+        const createdRecord = await response.json();
+        TriageQueueClient.push(createdRecord.id); // Push the ID to the queue
         logger.info(`Record created: ${JSON.stringify(recordData)}`);
         setError('');
       } else {

--- a/mister-ed/src/pages/homepage/triage/RequestTriage.js
+++ b/mister-ed/src/pages/homepage/triage/RequestTriage.js
@@ -12,7 +12,7 @@ function RequestTriage() {
 	const [selectedHospital, setSelectedHospital] = useState('');
 	const [error, setError] = useState('');
   const navigate = useNavigate();
-  const [queuePosition, setQueuePosition] = useState(null);
+  const [showQueueMessage, setshowQueueMessage] = useState(false);
   const [triageRequestDescription, setTriageRequestDescription] = useState();
   const [user, setUser] = useState(null);
 
@@ -52,20 +52,6 @@ function RequestTriage() {
       setError('Please provide a reason.');
       return;
     }
-    
-    try {
-			// Fetch hospital data to get queue count
-			const hospitalData = await DatabaseClient.fetch(`hospitals/${selectedHospital}`);
-			const currentQueue = hospitalData.queue;
-			// Update hospital queue count
-			const newQueuePosition = currentQueue + 1;
-			await DatabaseClient.update(`hospitals/${selectedHospital}`, { queue: newQueuePosition });
-			// Display user's position in queue
-			setQueuePosition(newQueuePosition);
-		} catch (error) {
-			console.error('Error updating queue:', error);
-			setError('Could not submit request. Please try again.');
-		}
   
     try {
       const recordData = {
@@ -80,12 +66,15 @@ function RequestTriage() {
       const response = await DatabaseClient.post('triage_records', recordData);
       if (response.ok) {
         const createdRecord = await response.json();
-        TriageQueueClient.push(createdRecord.id); // Push the ID to the queue
+        const queueClient = new TriageQueueClient(selectedHospital);
+        await queueClient.push(createdRecord.id); // Push the ID to the queue for the selected hospital
         logger.info(`Record created: ${JSON.stringify(recordData)}`);
         setError('');
       } else {
         throw new Error('Failed to create record');
       }
+
+      setshowQueueMessage(true);
     
     } catch (error) {
       setError('Could not submit request. Please try again.');
@@ -128,10 +117,9 @@ function RequestTriage() {
       </div>
       {/* Main content */}
       <div style={{ maxWidth: '400px', margin: '0 auto', textAlign: 'center', marginTop: '50px' }}>
-        {queuePosition ? (
+        {showQueueMessage ? (
           <p>
             You are in the queue for <strong>{selectedHospitalDetails?.name}</strong>.
-            Your position in the queue: {queuePosition}
           </p>
         ) : (
           <form onSubmit={handleSubmit}>

--- a/mister-ed/src/pages/homepage/triage/Triage.js
+++ b/mister-ed/src/pages/homepage/triage/Triage.js
@@ -11,6 +11,7 @@ function Triage() {
   const [triageRecords, setTriageRecords] = useState([]);
   const [selectedRecord, setSelectedRecord] = useState(null);
   const [nurseName, setNurseName] = useState(null);
+  const [hospitalName, setHospitalName] = useState(null);
   const navigate = useNavigate();
   const [showInitialMessage, setShowInitialMessage] = useState(true);
 
@@ -58,9 +59,26 @@ function Triage() {
     }
   };
   
+  const getHospitalName = async (hospitalID) => {
+    if (!hospitalID) {
+      setHospitalName("Unknown");
+      return;
+    }
+    try {
+      const data = await DatabaseClient.fetch('hospitals');
+      const foundHospital = data?.find((hospital) => hospital.id === hospitalID);
+      setHospitalName(foundHospital ? foundHospital.name : "Unknown");
+    } catch (error) {
+      logger.info('Failure fetching data');
+      console.error('Error fetching data:', error);
+      setHospitalName("Unknown");
+    }
+  };
+  
   useEffect(() => {
     if (selectedRecord) {
       getNurseName(selectedRecord.nurseID);
+      getHospitalName(selectedRecord.hospitalID);
     }
   }, [selectedRecord]); // Trigger when selectedRecord changes
   
@@ -155,6 +173,7 @@ function Triage() {
             {selectedRecord && (
               <div style={{ marginTop: '50px', textAlign: 'left' }}>
                 <div><strong>Date:</strong> {formatDate(selectedRecord.lastModified)}</div>
+                <div><strong>Hospital:</strong> {hospitalName}</div>
                 <div><strong>Description:</strong> {selectedRecord.description}</div>
                 <div><strong>Outcome:</strong> {selectedRecord.outcome}</div>
                 <div><strong>Nurse:</strong> {nurseName}</div>

--- a/mister-ed/src/pages/homepage/triage/Triage.js
+++ b/mister-ed/src/pages/homepage/triage/Triage.js
@@ -120,6 +120,17 @@ function Triage() {
               color="error"
               fullWidth
               style={{ padding: '20px' }}
+              onClick={() => navigate('/perform-triage')}
+            >
+              Perform Triage
+            </Button>
+          </Grid>
+          <Grid item xs={6}>
+            <Button
+              variant="contained"
+              color="error"
+              fullWidth
+              style={{ padding: '20px' }}
               onClick={() => navigate('/request-triage')}
             >
               Request Triage

--- a/mister-ed/src/servers/TriageQueueServer.js
+++ b/mister-ed/src/servers/TriageQueueServer.js
@@ -8,33 +8,45 @@ const PORT = 3003;
 app.use(express.json());
 app.use(cors()); // Allow all origins (for development purposes)
 
-// In-memory queue (stored as an array)
-let queue = [];
+// In-memory queues (keyed by hospitalID)
+const hospitalQueues = {};
 
-// Endpoint to add (push) an item to the queue
-app.post('/queue', (req, res) => {
+// Helper to get or create a queue for a hospital
+const getOrCreateQueue = (hospitalID) => {
+    if (!hospitalQueues[hospitalID]) hospitalQueues[hospitalID] = [];
+    return hospitalQueues[hospitalID];
+};
+
+// Endpoint to add (push) an item to the queue for a specific hospital
+app.post('/queue/:hospitalID', (req, res) => {
+    const { hospitalID } = req.params; // Get hospitalID from URL parameters
     const { item } = req.body; // Expecting JSON body like { "item": "some value" }
 
     if (item === undefined) {
         return res.status(400).json({ error: 'No item provided' });
     }
 
+    const queue = getOrCreateQueue(hospitalID);
     queue.push(item); // Add item to the end of the queue
     res.json({ message: 'Item added to queue', item });
 });
 
-// Endpoint to remove (pop) an item from the queue
-app.delete('/queue', (req, res) => {
+// Endpoint to remove (pop) an item from the queue for a specific hospital
+app.delete('/queue/:hospitalID', (req, res) => {
+    const { hospitalID } = req.params; // Get hospitalID from URL parameters
+    const queue = getOrCreateQueue(hospitalID);
     if (queue.length === 0) {
-        return res.status(200).json({ message: 'Queue is empty' });
+        return res.status(400).json({ error: 'Queue is empty', message: 'Queue is empty' });
     }
 
     const item = queue.shift(); // Remove item from the front of the queue
     res.json({ item });
 });
 
-// Endpoint to view the queue
-app.get('/queue', (req, res) => {
+// Endpoint to view the queue for a specific hospital
+app.get('/queue/:hospitalID', (req, res) => {
+    const { hospitalID } = req.params; // Get hospitalID from URL parameters
+    const queue = getOrCreateQueue(hospitalID);
     res.json({ queue });
 });
 


### PR DESCRIPTION
This completes #30 by implementing dynamic triage queues based on `hospitalID`.

# Here's a summary of what I did:

- I created the [useNextPatient](https://github.com/SENG-350-2024-fall/Team-8/blob/30-triage-queue-hospital-specificity/mister-ed/src/hooks/useNextPatient.js) hook and the [QueueContext](https://github.com/SENG-350-2024-fall/Team-8/blob/30-triage-queue-hospital-specificity/mister-ed/src/context/QueueContext.js) context to help get the queue for the nurse’s hospital

- In order to have a queue for each hospital, the [TriageQueueClient](https://github.com/SENG-350-2024-fall/Team-8/blob/30-triage-queue-hospital-specificity/mister-ed/src/clients/TriageQueueClient.js) is no longer a singleton

- I gave each nurse and doctor a `hospitalID` in [db.json](https://github.com/SENG-350-2024-fall/Team-8/blob/30-triage-queue-hospital-specificity/mister-ed/db.json)

- Upon login, the `hospitalID` gets stored with the rest of the user data in local storage (only for nurses and doctors)

- [TriageQueueServer](https://github.com/SENG-350-2024-fall/Team-8/blob/30-triage-queue-hospital-specificity/mister-ed/src/servers/TriageQueueServer.js) now uses a `hospitalID` in the endpoint

- The nurse’s ID gets added to the triage record when they submit their response to the triage request

- I added a “Perform Triage” button on the main triage page

- The profile page for nurses and doctors shows their hospital

**NOTE:** Recall that when a patient requests triage, a triage record is created. Additionally, the ID of this triage record is now added to a queue as soon as the request is submitted. Therefore, any triage records that already existed in the database before the app was started will not show in the queue.
