### PR TITLE
Customize triage page view based on user role

### DIFF
--- a/mister-ed/src/pages/homepage/triage/Triage.js
+++ b/mister-ed/src/pages/homepage/triage/Triage.js
@@ -22,7 +22,10 @@ function Triage() {
       try {
         const parsedUser = JSON.parse(userData);
         setUser(parsedUser);
-        fetchTriageRecords(parsedUser.id); // Use parsedUser.id directly to avoid relying on delayed state update and prevent race condition
+        // Fetch triage records for patients
+        if (parsedUser.role === "Patient") {
+          fetchTriageRecords(parsedUser.id); // Use parsedUser.id directly to avoid relying on delayed state update and prevent race condition
+        }
       } catch (error) {
         logger.error(`Error parsing user data in Triage Page`, error);
       }
@@ -114,86 +117,94 @@ function Triage() {
               Home Page
             </Button>
           </Grid>
-          <Grid item xs={6}>
-            <Button
-              variant="contained"
-              color="error"
-              fullWidth
-              style={{ padding: '20px' }}
-              onClick={() => navigate('/perform-triage')}
-            >
-              Perform Triage
-            </Button>
-          </Grid>
-          <Grid item xs={6}>
-            <Button
-              variant="contained"
-              color="error"
-              fullWidth
-              style={{ padding: '20px' }}
-              onClick={() => navigate('/request-triage')}
-            >
-              Request Triage
-            </Button>
-          </Grid>
+          {user && user.role === "Nurse" && (
+            <Grid item xs={6}>
+              <Button
+                variant="contained"
+                color="error"
+                fullWidth
+                style={{ padding: '20px' }}
+                onClick={() => navigate('/perform-triage')}
+              >
+                Perform Triage
+              </Button>
+            </Grid>
+          )}
+          {user && user.role === "Patient" && (
+            <Grid item xs={6}>
+              <Button
+                variant="contained"
+                color="error"
+                fullWidth
+                style={{ padding: '20px' }}
+                onClick={() => navigate('/request-triage')}
+              >
+                Request Triage
+              </Button>
+            </Grid>
+          )}
         </Grid>
       </div>
         
       {/* Message */}
-      {triageRecords.length > 0 ? (
-        showInitialMessage && (
-          <div style={{ textAlign: 'center', margin: '0 auto', marginTop: '50px'}}>
-            Below are the results from your last triage. Alternatively, you may view results from any of your past triages.
-          </div>
-        )
-      ) : (
-        <div style={{ textAlign: 'center', margin: '0 auto', marginTop: '50px'}}>
-          You have no triage results to display. Your results from all future triages will be available here.
-        </div>
-      )}
-        
-      <div style={{ maxWidth: '400px', margin: '0 auto', textAlign: 'center', marginTop: '50px' }}>
-        
-        {/* Dropdown to select record */}
-        {triageRecords.length > 0 && (
-          <FormControl fullWidth margin='normal'>
-            <InputLabel id='record-select-label'>
-              Triage Record
-            </InputLabel>
-            <Select
-              labelId='record-select-label'
-              value={selectedRecord?.id || ""}
-              onChange={(e) => {
-                const selectedId = e.target.value;
-                const record = triageRecords.find((rec) => rec.id === selectedId);
-                setSelectedRecord(record);
-                getNurseName(record.nurseID);
-                // Hide the initial message once the selected record is different from the initially selected record (i.e., the latest)
-                if (record.id != triageRecords[0].id) setShowInitialMessage(false);
-              }}
-              fullWidth
-            >
-              {triageRecords.map((record) => (
-                <MenuItem key={record.id} value={record.id}>
-                  {formatDate(record.lastModified)} - {record.description}
-                </MenuItem>
-              ))}
-            </Select>
-            
-            {/* Display details for selected record */}
-            {selectedRecord && (
-              <div style={{ marginTop: '50px', textAlign: 'left' }}>
-                <div><strong>Date:</strong> {formatDate(selectedRecord.lastModified)}</div>
-                <div><strong>Hospital:</strong> {hospitalName}</div>
-                <div><strong>Description:</strong> {selectedRecord.description}</div>
-                <div><strong>Outcome:</strong> {selectedRecord.outcome}</div>
-                <div><strong>Nurse:</strong> {nurseName}</div>
+      {user && user.role === "Patient" && (
+        <>
+          {triageRecords.length > 0 ? (
+            showInitialMessage && (
+              <div style={{ textAlign: 'center', margin: '0 auto', marginTop: '50px'}}>
+                Below are the results from your last triage. Alternatively, you may view results from any of your past triages.
               </div>
-            )}
+            )
+          ) : (
+            <div style={{ textAlign: 'center', margin: '0 auto', marginTop: '50px'}}>
+              You have no triage results to display. Your results from all future triages will be available here.
+            </div>
+          )}
             
-          </FormControl>
-        )}
-      </div>
+          <div style={{ maxWidth: '400px', margin: '0 auto', textAlign: 'center', marginTop: '50px' }}>
+            
+            {/* Dropdown to select record */}
+            {triageRecords.length > 0 && (
+              <FormControl fullWidth margin='normal'>
+                <InputLabel id='record-select-label'>
+                  Triage Record
+                </InputLabel>
+                <Select
+                  labelId='record-select-label'
+                  value={selectedRecord?.id || ""}
+                  onChange={(e) => {
+                    const selectedId = e.target.value;
+                    const record = triageRecords.find((rec) => rec.id === selectedId);
+                    setSelectedRecord(record);
+                    getNurseName(record.nurseID);
+                    // Hide the initial message once the selected record is different from the initially selected record (i.e., the latest)
+                    if (record.id != triageRecords[0].id) setShowInitialMessage(false);
+                  }}
+                  fullWidth
+                >
+                  {triageRecords.map((record) => (
+                    <MenuItem key={record.id} value={record.id}>
+                      {formatDate(record.lastModified)} - {record.description}
+                    </MenuItem>
+                  ))}
+                </Select>
+                
+                {/* Display details for selected record */}
+                {selectedRecord && (
+                  <div style={{ marginTop: '50px', textAlign: 'left' }}>
+                    <div><strong>Date:</strong> {formatDate(selectedRecord.lastModified)}</div>
+                    <div><strong>Hospital:</strong> {hospitalName}</div>
+                    <div><strong>Description:</strong> {selectedRecord.description}</div>
+                    <div><strong>Outcome:</strong> {selectedRecord.outcome}</div>
+                    <div><strong>Nurse:</strong> {nurseName}</div>
+                  </div>
+                )}
+                
+              </FormControl>
+            )}
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Problems arise when unintended users access either the "Request Triage" or "Perform Triage" pages. We may want other users to interact with these pages in the future, but right now they are designed only for specific users.

**Changes:**

- Patients can only see the “Request Triage” button 
- Nurses can only see the “Perform Triage” button 
- Other users cannot see the “Request Triage” or “Perform Triage” buttons